### PR TITLE
exploration of printing button on the pages to strip the css and print text on pages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13004,6 +13004,11 @@
       "integrity": "sha512-BXq3jwIagosjgNVae6tkHzzIk6a8MHFtzAdwhnV5VlvPTFxDCvIttgSiHWjdGoTJvXtmRu5HacExfdarRcFhog==",
       "dev": true
     },
+    "vue-html-to-paper": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/vue-html-to-paper/-/vue-html-to-paper-1.4.3.tgz",
+      "integrity": "sha512-h5SjbFnqEXv7F0Cq1k9IPljDaARR/z9PqirqmnebDNh0wrM2nbVAuOeEMdhnPCRHTy8XJbflAdG3J21o7y8X/g=="
+    },
     "vue-loader": {
       "version": "15.9.7",
       "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-15.9.7.tgz",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "register-service-worker": "^1.7.1",
     "vue": "^2.6.12",
     "vue-cheetah-grid": "^0.22.3",
+    "vue-html-to-paper": "^1.4.3",
     "vue-prism-component": "^1.2.0",
     "vue-router": "^3.1.6",
     "vuetify": "^2.2.21",

--- a/src/components/FAQ/faqInfo.vue
+++ b/src/components/FAQ/faqInfo.vue
@@ -1,5 +1,6 @@
 <template>
   <v-container fluid>
+  <v-btn @click="expandAll">Expand All</v-btn>
     <v-expansion-panels focusable hover tile multiple v-model="panel">
       <v-expansion-panel v-for="(faq, index) in faqs" :key="index">
         <v-expansion-panel-header class="" style="font-weight: 300; font-size:120% ">
@@ -77,6 +78,12 @@ export default {
       }
     }
   },
+  mounted() {
+    Event.$on('printPrep', () => {
+      this.panel = [1,2,3]
+      console.log(this.panel)
+    })
+  },
   methods : {
     lookupOrder(name) {
       var i;
@@ -86,6 +93,11 @@ export default {
           return i;
         }
       }
+    },
+    expandAll() {
+      console.log(this.faqs.length)
+      this.panel = [1,2,3,4,5,6]//Array(this.faqs.length)
+      console.log(this.panel)
     }
   }
 };

--- a/src/components/core/PrintButton.vue
+++ b/src/components/core/PrintButton.vue
@@ -1,0 +1,22 @@
+<template>
+    <v-btn outlined @click="print"><slot></slot></v-btn>
+</template>
+
+<script>
+export default {
+  data () {
+    return {
+      output: null
+    }
+  },
+  props: {
+      printId: String,
+  },
+  methods: {
+    async print () {
+      Event.$emit('printPrep')
+      await this.$htmlToPaper(this.printId);
+    }
+  }
+}
+</script>

--- a/src/components/core/Toolbar.vue
+++ b/src/components/core/Toolbar.vue
@@ -39,6 +39,7 @@
       @click="onClick($event, link)"
     >{{ link.text }}</v-btn>
     <!--<PushNotification />-->
+    <PrintButton :printId="this.$route.name">Print Page</PrintButton>
     <v-btn icon v-on:click="darkMode" class="ml-2">
       <v-icon v-if="this.$vuetify.theme.dark">mdi-brightness-7</v-icon>
       <v-icon v-else>mdi-brightness-4</v-icon>
@@ -49,6 +50,7 @@
 <script>
 import communityData from "@/assets/data/communityData.json";
 import feedbackModal from "@/components/core/FeedbackModal.vue";
+import PrintButton from "@/components/core/PrintButton.vue"
 // import PushNotification from "@/components/core/PushNotifications";
 import { mapMutations, mapGetters } from "vuex";
 export default {
@@ -59,6 +61,7 @@ export default {
   },
   components: {
     feedbackModal: feedbackModal,
+    PrintButton: PrintButton
   },
   computed: {
     metalinks() {

--- a/src/components/home/homeScreen.vue
+++ b/src/components/home/homeScreen.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-container fluid class="py-0">
+  <v-container fluid class="py-0" id="homepage-template">
     <v-row align="center">
       <!-- <v-col md="3" sm="5">
         <v-img

--- a/src/main.js
+++ b/src/main.js
@@ -10,21 +10,31 @@ import "./style.css";
 // import firebase from "@/firebase";
 import cssVars from "css-vars-ponyfill";
 import Prism from 'prismjs';
+import VueHtmlToPaper from 'vue-html-to-paper';
 Prism.highlightAll();
 
 cssVars({
   watch: true,
 });
 
+// const printOptions = {
+//   "styles": [
+//     // "https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css",
+//     // "https://unpkg.com/kidlat-css/css/kidlat.css",
+//     "src/style.css"
+//   ]
+// }
+
 IntersectionObserver.prototype.POLL_INTERVAL = 100; // time in ms
 
 Vue.config.productionTip = false;
 
 // firebase.auth.onAuthStateChanged(() => {
-  new Vue({
+  window.Event = new Vue({
     router,
     store,
     vuetify,
     render: h => h(App)
   }).$mount("#app");
+  Vue.use(VueHtmlToPaper);
 // });

--- a/src/views/Faq.vue
+++ b/src/views/Faq.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-container fluid class="pa-0 ma-0">
+  <v-container fluid class="pa-0 ma-0" :id="this.$route.name">
     <v-row justify="center" align="center" class="mx-0">
       <v-col cols="12" lg="10" class="pa-0">
         <Header>

--- a/src/views/GettingStarted.vue
+++ b/src/views/GettingStarted.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-container fluid class="pa-0 ma-0">
+  <v-container fluid class="pa-0 ma-0" :id="this.$route.name">
     <v-row justify="center" align="center" class="mx-0">
       <v-col cols="12" lg="10" class="pa-0">
         <Header>

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-container fluid class="pa-0 ma-0">
+  <v-container fluid class="pa-0 ma-0" :id="this.$route.name">
     <v-row justify="center" align="center" class="mx-0">
       <v-col cols="12" lg="10">
         <homeStartScreen class="mb-4" />
@@ -118,7 +118,7 @@
     components: {
       homeStartScreen,
       whatwedo,
-      wwdBasicCard,
+      wwdBasicCard
       //aboutCommunity,
       //events,
       //featureEvents,

--- a/src/views/Implementation.vue
+++ b/src/views/Implementation.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-container fluid class="pa-0 ma-0">
+  <v-container fluid class="pa-0 ma-0" :id="this.$route.name">
     <v-row justify="center" align="center" class="mx-0">
       <v-col cols="12" lg="10" class="pa-0 ma-0">
         <Header>

--- a/src/views/News.vue
+++ b/src/views/News.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-container fluid class="pa-0 ma-0">
+  <v-container fluid class="pa-0 ma-0" :id="this.$route.name">
     <v-row justify="center" align="center" class="mx-0">
       <v-col cols="12" lg="10" class="pa-0">
         <Header>

--- a/src/views/Normalize.vue
+++ b/src/views/Normalize.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-container fluid class="pa-0 ma-0">
+  <v-container fluid class="pa-0 ma-0" :id="this.$route.name">
     <v-row justify="center" align="center" class="mx-0">
       <v-col cols="12" lg="10" class="pa-0 ma-0">
         <Header>

--- a/src/views/Training.vue
+++ b/src/views/Training.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-container fluid class="pa-0 ma-0">
+  <v-container fluid class="pa-0 ma-0" :id="this.$route.name">
     <v-row justify="center" align="center" class="mx-0">
       <v-col cols="12" lg="10" class="pa-0">
         <Header>

--- a/src/views/Validation.vue
+++ b/src/views/Validation.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-container fluid class="pa-0 ma-0">
+  <v-container fluid class="pa-0 ma-0" :id="this.$route.name">
     <v-row justify="center" align="center" class="mx-0">
       <v-col cols="12" lg="10" class="pa-0 ma-0">
         <Header>


### PR DESCRIPTION
Found a Vue plugin that allows for adding print buttons to the pages -- by default it strips out all css and just dumps text and links to the file, which is easier than trying to get all the Vue components on the site to work with just printing the page via the browser itself.

Added a "Print Page" button to the navbar that will print the current page via this method.

This isn't perfect -- it can't interact with Vue components and can't print text that is hidden under a component (like the FAQ dropdowns). The big visual components on the homepage don't render correctly. Would likely be prohibitively time-consuming to get the heavily visual pages to work this way, but some value for pages that are mostly text (Normalize, What's New, etc.)

Reference #79 

Signed-off-by: Will Dower <wdower@mitre.org>